### PR TITLE
Support submodules

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -210,7 +210,7 @@ plug -params 1.. -shell-script-candidates %{ ls -1 ${kak_opt_plug_install_dir} }
                         current_branch=$(git branch | awk '/^\*/ { print $2 }')
                         [ "${current_branch}" != "${checkout}" ] && git fetch >/dev/null 2>&1
                     fi
-                    git checkout ${checkout} >/dev/null 2>&1
+                    git checkout --recurse-submodules ${checkout} >/dev/null 2>&1
                 )
             fi
             if [ -z "${noload}" ]; then {
@@ -321,7 +321,7 @@ plug-install -params ..1 %{ nop %sh{ (
                 plugin_log="${TMPDIR:-/tmp}/${plugin_name}-log"
                 printf "%s\n" "hook global -always KakEnd .* %{ nop %sh{rm -rf ${plugin_log}}}
                                evaluate-commands -client ${kak_client:-client0} %{ plug-update-fifo %{${plugin_name}} %{Installing} }" | kak -p ${kak_session}
-                cd ${kak_opt_plug_install_dir} && git clone "$remote" >>${plugin_log} 2>&1
+                cd ${kak_opt_plug_install_dir} && git clone --recurse-submodules "$remote" >>${plugin_log} 2>&1
                 status=$?
                 if [ ${status} -ne 0 ]; then
                     printf "%s\n" "evaluate-commands -client ${kak_client:-client0} %{ plug-update-fifo %{${plugin_name}} %{Download Error (${status})} }" | kak -p ${kak_session}

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -312,16 +312,16 @@ plug-install -params ..1 %{ nop %sh{ (
         if [ ! -d "${kak_opt_plug_install_dir}/${plugin_name}" ]; then
             case ${plugin} in
                 (http*|git*)
-                    git="git clone ${plugin}" ;;
+                    remote=${plugin} ;;
                 (*)
-                    git="git clone ${git_domain}/${plugin}" ;;
+                    remote=${git_domain}/${plugin} ;;
             esac
 
             (
                 plugin_log="${TMPDIR:-/tmp}/${plugin_name}-log"
                 printf "%s\n" "hook global -always KakEnd .* %{ nop %sh{rm -rf ${plugin_log}}}
                                evaluate-commands -client ${kak_client:-client0} %{ plug-update-fifo %{${plugin_name}} %{Installing} }" | kak -p ${kak_session}
-                cd ${kak_opt_plug_install_dir} && ${git} >>${plugin_log} 2>&1
+                cd ${kak_opt_plug_install_dir} && git clone "$remote" >>${plugin_log} 2>&1
                 status=$?
                 if [ ${status} -ne 0 ]; then
                     printf "%s\n" "evaluate-commands -client ${kak_client:-client0} %{ plug-update-fifo %{${plugin_name}} %{Download Error (${status})} }" | kak -p ${kak_session}


### PR DESCRIPTION
I was trying to use this to install https://github.com/ul/kak-tree/ which failed to compile because the submodules were not checked out. I'm sure I could have done `git submodule update init --recursive` in the `do` block but this seems like something plug.kak should take care.

Note: I'm using a relatively new arg to git, `--recurse-submodules`, though it is +3years old at this point. I think its worth using it unless someone brings it up as an issue?