### PR TITLE
Use printf instead of echo in plug_install_dir

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -15,7 +15,7 @@ declare-option -docstring \
 "Path where plugins should be installed.
 
     Defaults to the plug.kak installation directory" \
-str plug_install_dir %sh{ echo "${kak_source%%/rc*}/../" }
+str plug_install_dir %sh{ printf %s "${kak_source%%/rc*}/../" }
 
 declare-option -docstring \
 "Default domain to access git repositories. Can be changed to any preferred domain, like gitlab, bitbucket, gitea, etc.


### PR DESCRIPTION
In addition to the wiki preferring `printf` over `echo` (https://github.com/mawww/kakoune/wiki/Shell-scripting#why-should-printf-be-favored-over-echo), this makes it possible to keep trailing newlines from shell expansions (see https://github.com/mawww/kakoune/issues/3988).